### PR TITLE
Workaround for broken format on Windows

### DIFF
--- a/git-recent
+++ b/git-recent
@@ -24,7 +24,7 @@ $branch|\
 %(color:yellow)%(upstream:track)%(color:reset)
 $spacer|\
 %(contents:subject)
-|"
+$spacer|"
 
 lessopts="--tabs=4 --quit-if-one-screen --RAW-CONTROL-CHARS --no-init"
 

--- a/git-recent
+++ b/git-recent
@@ -6,14 +6,17 @@
 ## list all local branches, sorted by last commit, formatted reall purdy
 ##
 
-# Msys needs more basic format (git-for-windows/git#865)
-if [ "$(uname -o)" != "Msys" ]; then
-  branch='%(color:yellow)%(refname:short)%(color:reset)'
-  spacer='%(color:black) %(color:reset)'
-else
-  branch='%(refname:short)'
-  spacer=' '
-fi
+# Windows needs more basic format (#8, git-for-windows/git#865)
+case $(uname -s) in
+  CYGWIN*|MINGW32*|MSYS*)
+    branch='%(refname:short)'
+    spacer=' '
+    ;;
+  *)
+    branch='%(color:yellow)%(refname:short)%(color:reset)'
+    spacer='%(color:black) %(color:reset)'
+    ;;
+esac
 
 format="\
 %(HEAD) \

--- a/git-recent
+++ b/git-recent
@@ -12,6 +12,14 @@ format="\
   %(color:black) %(color:reset)|%(contents:subject)%0a\
   |"
 
+## workaround for Windows (#8)
+if [ "$(uname -o)" == "Msys" ]; then
+  format="\
+%(HEAD) %(refname:short)|\
+%(color:bold red)%(objectname:short) %(color:bold green)(%(committerdate:relative)) %(color:blue)%(authorname) %(color:reset)%(color:yellow)%(upstream:track)%0a\
+|%(contents:subject)%0a"
+fi
+
 lessopts="--tabs=4 --quit-if-one-screen --RAW-CONTROL-CHARS --no-init"
 
 git for-each-ref \

--- a/git-recent
+++ b/git-recent
@@ -6,19 +6,25 @@
 ## list all local branches, sorted by last commit, formatted reall purdy
 ##
 
-format="\
-%(HEAD) %(color:yellow)%(refname:short)%(color:reset)|\
-%(color:bold red)%(objectname:short) %(color:bold green)(%(committerdate:relative)) %(color:blue)%(authorname) %(color:reset)%(color:yellow)%(upstream:track)%0a\
-  %(color:black) %(color:reset)|%(contents:subject)%0a\
-  |"
-
-## workaround for Windows (#8)
-if [ "$(uname -o)" == "Msys" ]; then
-  format="\
-%(HEAD) %(refname:short)|\
-%(color:bold red)%(objectname:short) %(color:bold green)(%(committerdate:relative)) %(color:blue)%(authorname) %(color:reset)%(color:yellow)%(upstream:track)%0a\
-|%(contents:subject)%0a"
+# Msys needs more basic format (git-for-windows/git#865)
+if [ "$(uname -o)" != "Msys" ]; then
+  branch='%(color:yellow)%(refname:short)%(color:reset)'
+  spacer='%(color:black) %(color:reset)'
+else
+  branch='%(refname:short)'
+  spacer=' '
 fi
+
+format="\
+%(HEAD) \
+$branch|\
+%(color:bold red)%(objectname:short)%(color:reset) \
+%(color:bold green)(%(committerdate:relative))%(color:reset) \
+%(color:bold blue)%(authorname)%(color:reset) \
+%(color:yellow)%(upstream:track)%(color:reset)
+$spacer|\
+%(contents:subject)
+|"
 
 lessopts="--tabs=4 --quit-if-one-screen --RAW-CONTROL-CHARS --no-init"
 


### PR DESCRIPTION
**Before**

![1-before](https://cloud.githubusercontent.com/assets/143884/18026209/aebb6236-6c3f-11e6-92b2-f62304f01314.png)

**After**

![2-after](https://cloud.githubusercontent.com/assets/143884/18026210/b22e2b42-6c3f-11e6-9c53-e43f5c4b9675.png)

Essentially, this trades yellow refnames with proper alignment. Once `column` is fixed, this can then be burned to ashes. **This only affects Windows.**

Ref. #8
