### PR TITLE
Add count parameter

### DIFF
--- a/git-recent
+++ b/git-recent
@@ -18,6 +18,20 @@ case $(uname -s) in
     ;;
 esac
 
+while getopts "n:" opt; do
+  case ${opt} in
+    n )
+      if ! [[ $OPTARG =~ ^[0-9]{1,}$ ]]; then
+        echo "-n should be an integer."
+        exit 1
+      fi
+      COUNT=${OPTARG}
+      shift
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
 format="\
 %(HEAD) \
 $branch|\
@@ -33,6 +47,7 @@ lessopts="--tabs=4 --quit-if-one-screen --RAW-CONTROL-CHARS --no-init"
 
 git for-each-ref \
     --color=always \
+    --count=$COUNT \
     --sort=-committerdate \
     "refs/heads/"  \
     --format="$format" \
@@ -42,6 +57,7 @@ git for-each-ref \
 # The above command:
 #   for all known branches,
 #   (force coloring on this, especially since it's being piped)
+#   optionally, specify the number of branches you want to display
 #   sort descending by last commit
 #   show local branches (change to "" to include both local + remote branches)
 #   apply the formatting template above

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,13 @@ Type `git recent` to see your latest local git branches
     git recent
 
 
+Optionally add `-n <int>` to see the most recent `<n>` branches
+
+    git recent -n 5
+
 ![git-recent screenshot](https://cloud.githubusercontent.com/assets/39191/17446638/039d4cee-5aff-11e6-9e11-4294f0020513.png)
 
-If you're a Windows user, you need to use [Git Bash](https://git-scm.com/downloads) or similar shell in order to effectively use this utility. 
+If you're a Windows user, you need to use [Git Bash](https://git-scm.com/downloads) or similar shell in order to effectively use this utility.
 
 ### Installation
 
@@ -19,7 +23,7 @@ or copy `git-recent` into an existing included path like `/usr/local/bin` or `~/
 You can use also `npm` to install the global binary:
 
     npm install --global git-recent
-    
+
 On Mac, you can install with homebrew:
 
     brew install git-recent

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,9 @@ Type `git recent` to see your latest local git branches
     git recent
 
 
-Optionally add `-n <int>` to see the most recent `<n>` branches
+Optionally, add `-n<int>` to see the most recent `<n>` branches
 
-    git recent -n 5
+    git recent -n5
 
 ![git-recent screenshot](https://cloud.githubusercontent.com/assets/39191/17446638/039d4cee-5aff-11e6-9e11-4294f0020513.png)
 


### PR DESCRIPTION
Added a count parameter so users could see the last n ~~commits~~ branches.

Completely optional argument, see below:

usage:

`git recent`  default behavior
`git recent 0`  default behavior
`git recent 5`  last 5 ~~commits~~ branches returned, instead of all of them
`git recent ( n > number of total branches )`  default behavior

...and so on. 

