### PR TITLE
Handle new git behavior requiring count parameter

### DIFF
--- a/git-recent
+++ b/git-recent
@@ -18,6 +18,7 @@ case $(uname -s) in
     ;;
 esac
 
+COUNT=0
 while getopts "n:" opt; do
   case ${opt} in
     n )


### PR DESCRIPTION
@paulirish 

I ran into an issue today with `git-recent` where it was giving me an error:
```
error: option `count' expects a numerical value
```

I believe my build environment upgraded `git` with a new constraint on the `--count` parameter, as shown in this commit:
https://github.com/git/git/commit/20aa7c594fbc2e36476daae2f53d7c020306c62c#diff-15a33e465ac44642a84b00186e663b7f

Passing a count of `0` appears to behave the same way it used to when the count was missing. It does still render some strange `(null)` values (with or without the `-n` parameter), but I suspect that's yet another fix that may need to happen in addition to this one.
