### PR TITLE
chromium cl status integration

### DIFF
--- a/git-recent
+++ b/git-recent
@@ -85,7 +85,9 @@ _browse_branches() {
           continue
         fi
         review_url=$(echo "$CL_STATUS" | grep -E "\b${branch_name}\b" | grep -o -E 'https://.*' | sed 's|https://||')
-        printf "$YELLOW%s $DIM%s$NC\n" "$branch_name" "$review_url"
+        # Using fancy integrated hyperlinks: https://iterm2.com/feature-reporting/Hyperlinks_in_Terminal_Emulators.html
+        # TODO: maybe get rid of the crrev.com/c/ text as the link?
+        printf "$YELLOW%s $DIM\033]8;;%s\a%s\033]8;;\a$NC\n" "$branch_name" "https://$review_url" "$review_url"
       done \
     | fzf  \
         $filterarg --ansi -- --layout=reverse --multi --height=90% --min-height=20  \
@@ -98,12 +100,13 @@ _browse_branches() {
         --bind "ctrl-y:execute-silent($copy_cmd)" \
         --bind "ctrl-o:preview:$diffbranch_cmd" 
 } 
-chosen_branch="$(_browse_branches)"
-line_count=$(printf "%s" "$chosen_branch" | wc -l)
+output="$(_browse_branches)"
+line_count=$(printf "%s" "$output" | wc -l)
 
-if [[ -n "$chosen_branch" ]] && (( line_count == 0 )); then
+if [[ -n "$output" ]] && (( line_count == 0 )); then
+  chosen_branch=$(echo "$output" | cut -d' ' -f1)
   echo git checkout "$chosen_branch"
   git checkout "$chosen_branch"
 else
-  echo "$chosen_branch"
+  echo "$output"
 fi

--- a/git-recent
+++ b/git-recent
@@ -34,7 +34,7 @@ commits_format="%C(red bold)%h %C(bold blue)%an %C(bold green)%ad %Creset%s"
 # TODO: some branch mgmt approaches don't work well with this. And may prefer `git log --pretty=format:%H --merges -n 1`.  See https://github.com/paulirish/git-recent/issues/28
 diff_base=$(cat $(git rev-parse --show-cdup).git/refs/remotes/origin/HEAD | awk '{print $2}')
 
-uniqcommits_cmd="git log --date=human --color=always --format='$commits_format' --no-merges $diff_base..{1}"
+uniqcommits_cmd="branch_name=\$(echo {1} | cut -d' ' -f1) git log --date=human --color=always --format='$commits_format' --no-merges $diff_base..\$branch_name"
 
 diffbranch_cmd="git diff --color=always $diff_base...{}"
 # Progressive enhancement if you have delta or diff-so-fancy
@@ -56,6 +56,10 @@ elif command -v xsel >/dev/null; then
   copy_cmd="printf '%s' {} | xsel --clipboard"
 fi
 
+YELLOW='\033[0;33m'
+DIM='\033[2m'
+NC='\033[0m' # No Color
+
 # if extra arg passed (eg `git recent remotename`), then list those remote branches, rather than local ones
 [[ -n "$1" ]] && heads="refs/remotes/$1" || heads="refs/heads"
 
@@ -67,9 +71,39 @@ fi
 # If there's a GIT_RECENT_QUERY environment variable, use it for non-interactive filtering. (Primarily added for testing.)
 filterarg=${GIT_RECENT_QUERY:+"--filter=$GIT_RECENT_QUERY"}
 
+
+CL_STATUS=$(git cl status --fast --no-branch-color | grep 'https://' |  sed 's| (.*||')
+# CL_STATUS=$(cat <<'EOF'
+#                  delete-unused-things-june25 : https://crrev.com/c/6649316 (waiting)
+#                          download-branded-chrome : https://crrev.com/c/6333632 (waiting)
+#                          drop-micro-sec-entirely : https://crrev.com/c/6287827 (waiting)
+#                   editor-search-result-to-center : https://crrev.com/c/5958176 (waiting)
+#                                faster-ut-handler : https://crrev.com/c/6472820 (waiting)
+#                           initiator-arrow-reduxx : https://crrev.com/c/5309492 (waiting)
+#                                   insight-bounds : https://crrev.com/c/6436290 (waiting)
+#                              io-throttling-order : https://crrev.com/c/6535192 (waiting)
+#                              knapsack-for-victor : https://crrev.com/c/5981368 (waiting)
+#                          lcp-phase-mini-refactor : https://crrev.com/c/6651250 (waiting)
+#                                module-graph-test : https://crrev.com/c/6183179 (waiting)
+#                               negative-lcp-phase : https://crrev.com/c/6651013 (waiting)
+#                          react-ext-link-handling : https://crrev.com/c/6535878 (waiting)
+#             sidebar-reset-active-insight-on-hide : https://crrev.com/c/6433141 (waiting)
+#                                      url-eliding : https://crrev.com/c/6329935 (waiting)
+#                                   usertiming-fix : https://crrev.com/c/6533610 (waiting)
+#                                      verbosespec : https://crrev.com/c/6635126 (waiting)
+# EOF
+# )
+                  
+
+# echo "$CL_STATUS" 
+
 _browse_branches() {
-  git for-each-ref --color=always --sort=-authordate "$heads" --format="$branches_format" \
-    |  fzf  \
+  git for-each-ref --sort=-authordate "$heads" --format="$branches_format" \
+    | while read -r branch_name; do
+        review_url=$(echo "$CL_STATUS" | grep -E "\b${branch_name}\b" | grep -o -E 'https://.*' | sed 's|https://||')
+        printf "$YELLOW$branch_name $DIM$review_url\n"
+      done \
+    | fzf  \
         $filterarg --ansi -- --layout=reverse --multi --height=90% --min-height=20  \
         --border-label-pos=2 --border-label '🌲 Branches' --border \
         --no-hscroll --no-multi \

--- a/git-recent
+++ b/git-recent
@@ -27,7 +27,6 @@ fi
 
 # ---------------------------------------------------------------------------------------
 
-branches_format="%(color:yellow)%(refname:short)%(color:reset)"
 commits_format="%C(red bold)%h %C(bold blue)%an %C(bold green)%ad %Creset%s"
 
 # The HEAD of the primary branch (eg main or master or w/e), for diffing.
@@ -36,7 +35,7 @@ diff_base=$(cat $(git rev-parse --show-cdup).git/refs/remotes/origin/HEAD | awk 
 
 uniqcommits_cmd="branch_name=\$(echo {1} | cut -d' ' -f1) git log --date=human --color=always --format='$commits_format' --no-merges $diff_base..\$branch_name"
 
-diffbranch_cmd="git diff --color=always $diff_base...{}"
+diffbranch_cmd="branch_name=\$(echo {1} | cut -d' ' -f1) git diff --color=always $diff_base...\$branch_name"
 # Progressive enhancement if you have delta or diff-so-fancy
 if command -v delta >/dev/null 2>&1; then
   diffbranch_cmd="$diffbranch_cmd | delta"
@@ -60,8 +59,12 @@ YELLOW='\033[0;33m'
 DIM='\033[2m'
 NC='\033[0m' # No Color
 
+# if show_cl passed then also run git cl status. (chromium repos)
+[[ "$1" == "--cl" || "$1" == "-cl" ]] && show_cl=true || show_cl=false
+
 # if extra arg passed (eg `git recent remotename`), then list those remote branches, rather than local ones
-[[ -n "$1" ]] && heads="refs/remotes/$1" || heads="refs/heads"
+[[ -n "$1" && "$show_cl" != true ]] && heads="refs/remotes/$1" || heads="refs/heads"
+
 
 # fzf git inspiration:
 # - https://github.com/junegunn/fzf/wiki/Examples#git 
@@ -71,37 +74,18 @@ NC='\033[0m' # No Color
 # If there's a GIT_RECENT_QUERY environment variable, use it for non-interactive filtering. (Primarily added for testing.)
 filterarg=${GIT_RECENT_QUERY:+"--filter=$GIT_RECENT_QUERY"}
 
+CL_STATUS=$([ "$show_cl" = true ] && git cl status --fast --no-branch-color | grep 'https://' | sed 's| (.*||')
 
-CL_STATUS=$(git cl status --fast --no-branch-color | grep 'https://' |  sed 's| (.*||')
-# CL_STATUS=$(cat <<'EOF'
-#                  delete-unused-things-june25 : https://crrev.com/c/6649316 (waiting)
-#                          download-branded-chrome : https://crrev.com/c/6333632 (waiting)
-#                          drop-micro-sec-entirely : https://crrev.com/c/6287827 (waiting)
-#                   editor-search-result-to-center : https://crrev.com/c/5958176 (waiting)
-#                                faster-ut-handler : https://crrev.com/c/6472820 (waiting)
-#                           initiator-arrow-reduxx : https://crrev.com/c/5309492 (waiting)
-#                                   insight-bounds : https://crrev.com/c/6436290 (waiting)
-#                              io-throttling-order : https://crrev.com/c/6535192 (waiting)
-#                              knapsack-for-victor : https://crrev.com/c/5981368 (waiting)
-#                          lcp-phase-mini-refactor : https://crrev.com/c/6651250 (waiting)
-#                                module-graph-test : https://crrev.com/c/6183179 (waiting)
-#                               negative-lcp-phase : https://crrev.com/c/6651013 (waiting)
-#                          react-ext-link-handling : https://crrev.com/c/6535878 (waiting)
-#             sidebar-reset-active-insight-on-hide : https://crrev.com/c/6433141 (waiting)
-#                                      url-eliding : https://crrev.com/c/6329935 (waiting)
-#                                   usertiming-fix : https://crrev.com/c/6533610 (waiting)
-#                                      verbosespec : https://crrev.com/c/6635126 (waiting)
-# EOF
-# )
-                  
-
-# echo "$CL_STATUS" 
 
 _browse_branches() {
-  git for-each-ref --sort=-authordate "$heads" --format="$branches_format" \
+  git for-each-ref --sort=-authordate "$heads" --format="%(refname:short)" \
     | while read -r branch_name; do
+        if [ "$show_cl" != true ]; then
+          printf "$YELLOW$branch_name$NC\n"
+          continue
+        fi
         review_url=$(echo "$CL_STATUS" | grep -E "\b${branch_name}\b" | grep -o -E 'https://.*' | sed 's|https://||')
-        printf "$YELLOW$branch_name $DIM$review_url\n"
+        printf "$YELLOW$branch_name $DIM$review_url$NC\n"
       done \
     | fzf  \
         $filterarg --ansi -- --layout=reverse --multi --height=90% --min-height=20  \

--- a/git-recent
+++ b/git-recent
@@ -74,18 +74,18 @@ NC='\033[0m' # No Color
 # If there's a GIT_RECENT_QUERY environment variable, use it for non-interactive filtering. (Primarily added for testing.)
 filterarg=${GIT_RECENT_QUERY:+"--filter=$GIT_RECENT_QUERY"}
 
+# Chromium hackers may want reference to their relevant CL.
 CL_STATUS=$([ "$show_cl" = true ] && git cl status --fast --no-branch-color | grep 'https://' | sed 's| (.*||')
-
 
 _browse_branches() {
   git for-each-ref --sort=-authordate "$heads" --format="%(refname:short)" \
     | while read -r branch_name; do
         if [ "$show_cl" != true ]; then
-          printf "$YELLOW$branch_name$NC\n"
+          printf "$YELLOW%s$NC\n" "$branch_name"
           continue
         fi
         review_url=$(echo "$CL_STATUS" | grep -E "\b${branch_name}\b" | grep -o -E 'https://.*' | sed 's|https://||')
-        printf "$YELLOW$branch_name $DIM$review_url$NC\n"
+        printf "$YELLOW%s $DIM%s$NC\n" "$branch_name" "$review_url"
       done \
     | fzf  \
         $filterarg --ansi -- --layout=reverse --multi --height=90% --min-height=20  \


### PR DESCRIPTION
pet feature for me and chromium folks.
it adds no runtime cost for a regular user.

passing `-cl` or `--cl` will also pull in the chromium CL link. 

![image](https://github.com/user-attachments/assets/031c3495-6a97-4049-b9a3-86c3670c359c)

cmd-click to open those URLs.


and to be extra unfair, i may not be interested in extending the same feature for other systems like github etc. we'll see..