### PR TITLE
easy worktree switching

### DIFF
--- a/git-recent
+++ b/git-recent
@@ -29,7 +29,7 @@ fi
 
 # The HEAD of the primary branch (eg main or master or w/e), for diffing.
 # TODO: some branch mgmt approaches don't work well with this. And may prefer `git log --pretty=format:%H --merges -n 1`.  See https://github.com/paulirish/git-recent/issues/28
-diff_base=$(cat $(git rev-parse --show-cdup).git/refs/remotes/origin/HEAD | awk '{print $2}')
+diff_base=$(git symbolic-ref refs/remotes/origin/HEAD)
 
 # Extract branch name (without any trailing text, like the Chromium link)
 define_branchname="branchname=\\\$(echo {1} | cut -d' ' -f1)"

--- a/git-recent
+++ b/git-recent
@@ -128,14 +128,10 @@ if [[ -n "$output" ]] && (( line_count == 0 )); then
   wt_path=$(_get_worktree_for_branch "$chosen_branch")
 
   if [[ -n "$wt_path" ]]; then
-    echo "Branch '$chosen_branch' is open in worktree: $wt_path"
-    if [[ "$GIT_RECENT_AUTO_CD" == "1" ]]; then
-      echo "__CD__:$wt_path"
-    else
-      echo "To jump there, run: cd \"$wt_path\""
-    fi
+    echo "Branch '$chosen_branch' is open in worktree: $wt_path" >&2
+    echo "$wt_path"
   else
-    echo git checkout "$chosen_branch"
+    echo "git checkout $chosen_branch" >&2
     git checkout "$chosen_branch"
   fi
 else

--- a/git-recent
+++ b/git-recent
@@ -19,7 +19,7 @@ if [[ "$1" == "--help" ]]; then
   echo "git-recent: Browse and checkout recently used Git branches."
   echo
   echo "Keybindings:"
-  echo "  Enter:      Checkout the selected branch"
+  echo "  Enter:      Checkout the selected branch (or jump to its worktree if open elsewhere)"
   echo "  Ctrl-O:     Show the diff of the selected branch against the main/master branch"
   echo "  Ctrl-C:     Exit"
   exit 0
@@ -54,6 +54,24 @@ elif command -v xclip >/dev/null; then
 elif command -v xsel >/dev/null; then
   copy_cmd="printf '%s' {} | xsel --clipboard"
 fi
+
+_get_worktree_for_branch() {
+  local branch="$1"
+  local current_toplevel
+  current_toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+
+  # Find the worktree path for the given branch, excluding the current one.
+  # Using substr to handle paths with spaces correctly.
+  git worktree list --porcelain | awk -v target="refs/heads/$branch" -v current="$current_toplevel" '
+    /^worktree / { wt = substr($0, 10) }
+    /^branch / && $2 == target {
+      if (wt != current) {
+        print wt
+        exit
+      }
+    }
+  '
+}
 
 YELLOW='\033[0;33m'
 DIM='\033[2m'
@@ -106,8 +124,20 @@ line_count=$(printf "%s" "$output" | wc -l)
 
 if [[ -n "$output" ]] && (( line_count == 0 )); then
   chosen_branch=$(echo "$output" | cut -d' ' -f1)
-  echo git checkout "$chosen_branch"
-  git checkout "$chosen_branch"
+
+  wt_path=$(_get_worktree_for_branch "$chosen_branch")
+
+  if [[ -n "$wt_path" ]]; then
+    echo "Branch '$chosen_branch' is open in worktree: $wt_path"
+    if [[ "$GIT_RECENT_AUTO_CD" == "1" ]]; then
+      echo "__CD__:$wt_path"
+    else
+      echo "To jump there, run: cd \"$wt_path\""
+    fi
+  else
+    echo git checkout "$chosen_branch"
+    git checkout "$chosen_branch"
+  fi
 else
   echo "$output"
 fi

--- a/git-recent
+++ b/git-recent
@@ -95,18 +95,26 @@ filterarg=${GIT_RECENT_QUERY:+"--filter=$GIT_RECENT_QUERY"}
 # Chromium hackers may want reference to their relevant CL.
 CL_STATUS=$([ "$show_cl" = true ] && git cl status --fast --no-branch-color | grep 'https://' | sed 's| (.*||')
 
+# List of branches currently checked out in any worktree (including the current one)
+WT_BRANCHES=$(git worktree list --porcelain | grep "^branch " | sed 's|^branch refs/heads/||')
+
 _browse_branches() {
   git for-each-ref --sort=-authordate "$heads" --format="%(refname:short)" \
     | while read -r branch_name; do
+        wt_symbol=""
+        if echo "$WT_BRANCHES" | grep -qFx "$branch_name"; then
+          wt_symbol=" ⇶"
+        fi
+
         if [ "$show_cl" != true ]; then
-          printf "$YELLOW%s$NC\n" "$branch_name"
+          printf "$YELLOW%s$DIM%s$NC\n" "$branch_name" "$wt_symbol"
           continue
         fi
         review_url=$(echo "$CL_STATUS" | grep -E "\b${branch_name} :" | grep -o -E 'https://.*' | sed 's|https://||')
         # Using fancy integrated hyperlinks: https://iterm2.com/feature-reporting/Hyperlinks_in_Terminal_Emulators.html
         # TODO: maybe get rid of the crrev.com/c/ text as the link?
         # TODO: use `git config branch.$(git rev-parse --abbrev-ref HEAD).gerritissue` and gerritserver to avoid using `git cl status`
-        printf "$YELLOW%s $DIM\033]8;;%s\a%s\033]8;;\a$NC\n" "$branch_name" "https://$review_url" "$review_url"
+        printf "$YELLOW%s$DIM%s \033]8;;%s\a%s\033]8;;\a$NC\n" "$branch_name" "$wt_symbol" "https://$review_url" "$review_url"
       done \
     | fzf  \
         $filterarg --ansi -- --layout=reverse --multi --height=90% --min-height=20  \

--- a/git-watch
+++ b/git-watch
@@ -68,11 +68,11 @@ update() {
   local current_head last_head current_state_hash last_state_hash
   current_head=$(git rev-parse HEAD 2>/dev/null)
   
-  # Capture status, diff, and untracked files for hashing
-  local status_output=$(git status --porcelain)
+  # Capture status and diff for hashing (ignoring untracked files for now)
+  local status_output=$(git status --porcelain --untracked-files=no)
   local diff_output=$(git diff HEAD 2>/dev/null)
-  local untracked_files=$(git ls-files --others --exclude-standard)
-  current_state_hash=$( (echo "$status_output"; echo "$diff_output"; echo "$untracked_files") | $hash_cmd | cut -d' ' -f1)
+  # TODO: Re-evaluate untracked file support later.
+  current_state_hash=$( (echo "$status_output"; echo "$diff_output") | $hash_cmd | cut -d' ' -f1)
   
   if [[ -f "$state_file" && "$mode" != "--initial" ]]; then
     read -r last_head last_state_hash < "$state_file"
@@ -103,21 +103,7 @@ update() {
         git_run diff HEAD
       fi
       
-      # Untracked files handling
-      local count=$(echo "$untracked_files" | grep -c .)
-      if [[ $count -gt 0 ]]; then
-        if [[ $count -le 3 ]]; then
-          echo "$untracked_files" | while read -r f; do
-            if [[ -f "$f" ]]; then
-              echo -e "\033[1;33m[Untracked: $f]\033[0m"
-              git_run diff --no-index /dev/null "$f"
-            fi
-          done
-        else
-          echo -e "\033[1;33m[$count untracked files]\033[0m"
-          echo "$untracked_files" | sed 's/^/  /'
-        fi
-      fi
+      # TODO: Implement surgical untracked file support here if needed.
       did_something=true
     fi
   fi

--- a/git-watch
+++ b/git-watch
@@ -40,16 +40,19 @@ fi
 
 # Pager detection (compatible with delta, diff-so-fancy, etc.)
 pager_cmd=$(command -v delta || command -v diff-so-fancy)
-pipe_to_pager=${pager_cmd:+" | $pager_cmd"}
+if [ -n "$pager_cmd" ]; then
+  if [[ "$pager_cmd" == *"delta"* ]]; then
+    pager_cmd="$pager_cmd --paging=never"
+  fi
+  pipe_to_pager=" | $pager_cmd"
+fi
 
 git_run() {
   if [ "$DEBUG_MODE" = true ]; then
-    echo -e "\033[0;35m[DEBUG] Would run: git --no-pager \"$@\" --color=always $pipe_to_pager\033[0m"
+    echo -e "\033[0;35m[DEBUG] Would run: git --no-pager \"$@\" --color=always$pipe_to_pager\033[0m"
     return
   fi
-  # Use --no-pager to avoid interactive sessions
-  # Use --color=always to preserve color through the pipe
-  eval "git --no-pager \"\$@\" --color=always $pipe_to_pager"
+  eval "git --no-pager \"\$@\" --color=always$pipe_to_pager"
 }
 
 # Cross-platform hashing for change detection
@@ -65,10 +68,11 @@ update() {
   local current_head last_head current_state_hash last_state_hash
   current_head=$(git rev-parse HEAD 2>/dev/null)
   
-  # Capture staged, unstaged, and the presence of untracked files
+  # Capture status, diff, and untracked files for hashing
   local status_output=$(git status --porcelain)
   local diff_output=$(git diff HEAD 2>/dev/null)
-  current_state_hash=$( (echo "$status_output"; echo "$diff_output") | $hash_cmd | cut -d' ' -f1)
+  local untracked_files=$(git ls-files --others --exclude-standard)
+  current_state_hash=$( (echo "$status_output"; echo "$diff_output"; echo "$untracked_files") | $hash_cmd | cut -d' ' -f1)
   
   if [[ -f "$state_file" && "$mode" != "--initial" ]]; then
     read -r last_head last_state_hash < "$state_file"
@@ -76,38 +80,49 @@ update() {
 
   if [ "$DEBUG_MODE" = true ]; then
     echo -e "\033[0;35m[DEBUG] Mode: $mode\033[0m"
-    echo -e "\033[0;35m[DEBUG] HEAD: $current_head (Last: $last_head)\033[0m"
-    echo -e "\033[0;35m[DEBUG] State Hash: $current_state_hash (Last: $last_state_hash)\033[0m"
+    echo -e "\033[0;35m[DEBUG] HEAD: $current_head (Last: ${last_head:-NONE})\033[0m"
+    echo -e "\033[0;35m[DEBUG] State Hash: $current_state_hash (Last: ${last_state_hash:-NONE})\033[0m"
   fi
 
   local did_something=false
 
-  # 1. Commit detection (or initial show)
+  # 1. Commit detection
   if [[ "$current_head" != "$last_head" || "$mode" == "--initial" ]]; then
     echo -e "\n\033[1;34m=== Current Commit: $(git log -1 --format='%h %s' 2>/dev/null) ===\033[0m"
     git_run show --summary --stat -p
     did_something=true
   fi
 
-  # 2. Working directory detection (or initial show)
+  # 2. Working directory detection
   if [[ "$current_state_hash" != "$last_state_hash" || "$mode" == "--initial" ]]; then
     if [[ -n "$status_output" ]]; then
       echo -e "\n\033[1;32m=== Changes ===\033[0m"
       
-      # Show diff of tracked changes (staged and unstaged)
-      git_run diff HEAD
+      # Show diff of tracked changes
+      if [[ -n "$diff_output" ]]; then
+        git_run diff HEAD
+      fi
       
-      # Show untracked files content
-      git ls-files --others --exclude-standard | while read -r f; do
-        if [[ -f "$f" ]]; then
-          echo -e "\033[1;33m[Untracked: $f]\033[0m"
-          git_run diff --no-index /dev/null "$f"
+      # Untracked files handling
+      local count=$(echo "$untracked_files" | grep -c .)
+      if [[ $count -gt 0 ]]; then
+        if [[ $count -le 3 ]]; then
+          echo "$untracked_files" | while read -r f; do
+            if [[ -f "$f" ]]; then
+              echo -e "\033[1;33m[Untracked: $f]\033[0m"
+              git_run diff --no-index /dev/null "$f"
+            fi
+          done
+        else
+          echo -e "\033[1;33m[$count untracked files]\033[0m"
+          echo "$untracked_files" | sed 's/^/  /'
         fi
-      done
+      fi
       did_something=true
     fi
   fi
 
+  # Update state so we don't repeat this in the next --step
   if [[ "$did_something" == "true" ]]; then
     if [ "$DEBUG_MODE" = true ]; then
       echo -e "\033[0;35m[DEBUG] Would update state file: $current_head $current_state_hash\033[0m"
@@ -124,7 +139,6 @@ if [[ "$1" == "--step" ]]; then
 fi
 
 # Main execution loop
-# Always show the current state on launch
 update "--initial"
 
 pass_debug=""
@@ -134,12 +148,16 @@ fi
 
 if command -v watchexec >/dev/null 2>&1; then
   echo -e "\033[0;32mWatching with watchexec...\033[0m"
-  # -i .git: ignore most git internal changes
-  # -w .: watch working directory
-  # -w .git/HEAD: watch for commits
+  # --postpone: don't run immediately on start (we already did update --initial)
   # --quiet: suppress watchexec status messages
-  watchexec --quiet -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step $pass_debug
+  watchexec --quiet --postpone -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step $pass_debug
 else
+  echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
+  while true; do
+    update "--step"
+    sleep 2
+  done
+fi
   echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
   while true; do
     update "--step"

--- a/git-watch
+++ b/git-watch
@@ -19,7 +19,10 @@
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
   echo "git-watch: A streaming perspective of git changes and commits."
   echo
-  echo "Usage: git-watch"
+  echo "Usage: git-watch [--debug]"
+  echo
+  echo "Options:"
+  echo "  --debug     Log what would be run instead of running it"
   echo
   echo "Features:"
   echo "  - Shows 'git show' on new commits"
@@ -30,11 +33,20 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
   exit 0
 fi
 
+DEBUG_MODE=false
+if [[ "$1" == "--debug" || "$2" == "--debug" ]]; then
+  DEBUG_MODE=true
+fi
+
 # Pager detection (compatible with delta, diff-so-fancy, etc.)
 pager_cmd=$(command -v delta || command -v diff-so-fancy)
 pipe_to_pager=${pager_cmd:+" | $pager_cmd"}
 
 git_run() {
+  if [ "$DEBUG_MODE" = true ]; then
+    echo -e "\033[0;35m[DEBUG] Would run: git --no-pager \"$@\" --color=always $pipe_to_pager\033[0m"
+    return
+  fi
   # Use --no-pager to avoid interactive sessions
   # Use --color=always to preserve color through the pipe
   eval "git --no-pager \"\$@\" --color=always $pipe_to_pager"
@@ -54,10 +66,18 @@ update() {
   current_head=$(git rev-parse HEAD 2>/dev/null)
   
   # Capture staged, unstaged, and the presence of untracked files
-  current_state_hash=$( (git status --porcelain; git diff HEAD) | $hash_cmd | cut -d' ' -f1)
+  local status_output=$(git status --porcelain)
+  local diff_output=$(git diff HEAD 2>/dev/null)
+  current_state_hash=$( (echo "$status_output"; echo "$diff_output") | $hash_cmd | cut -d' ' -f1)
   
   if [[ -f "$state_file" && "$mode" != "--initial" ]]; then
     read -r last_head last_state_hash < "$state_file"
+  fi
+
+  if [ "$DEBUG_MODE" = true ]; then
+    echo -e "\033[0;35m[DEBUG] Mode: $mode\033[0m"
+    echo -e "\033[0;35m[DEBUG] HEAD: $current_head (Last: $last_head)\033[0m"
+    echo -e "\033[0;35m[DEBUG] State Hash: $current_state_hash (Last: $last_state_hash)\033[0m"
   fi
 
   local did_something=false
@@ -71,8 +91,7 @@ update() {
 
   # 2. Working directory detection (or initial show)
   if [[ "$current_state_hash" != "$last_state_hash" || "$mode" == "--initial" ]]; then
-    local status=$(git status --porcelain)
-    if [[ -n "$status" ]]; then
+    if [[ -n "$status_output" ]]; then
       echo -e "\n\033[1;32m=== Changes ===\033[0m"
       
       # Show diff of tracked changes (staged and unstaged)
@@ -90,7 +109,11 @@ update() {
   fi
 
   if [[ "$did_something" == "true" ]]; then
-    echo "$current_head $current_state_hash" > "$state_file"
+    if [ "$DEBUG_MODE" = true ]; then
+      echo -e "\033[0;35m[DEBUG] Would update state file: $current_head $current_state_hash\033[0m"
+    else
+      echo "$current_head $current_state_hash" > "$state_file"
+    fi
   fi
 }
 
@@ -104,13 +127,18 @@ fi
 # Always show the current state on launch
 update "--initial"
 
+pass_debug=""
+if [ "$DEBUG_MODE" = true ]; then
+  pass_debug="--debug"
+fi
+
 if command -v watchexec >/dev/null 2>&1; then
   echo -e "\033[0;32mWatching with watchexec...\033[0m"
   # -i .git: ignore most git internal changes
   # -w .: watch working directory
   # -w .git/HEAD: watch for commits
   # --quiet: suppress watchexec status messages
-  watchexec --quiet -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step
+  watchexec --quiet -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step $pass_debug
 else
   echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
   while true; do

--- a/git-watch
+++ b/git-watch
@@ -44,6 +44,7 @@ git_run() {
 hash_cmd=$(command -v shasum || command -v sha1sum || echo "cksum")
 
 update() {
+  local mode="$1"
   local git_dir state_file
   git_dir=$(git rev-parse --git-dir 2>/dev/null)
   [ -n "$git_dir" ] || return
@@ -55,21 +56,21 @@ update() {
   # Capture staged, unstaged, and the presence of untracked files
   current_state_hash=$( (git status --porcelain; git diff HEAD) | $hash_cmd | cut -d' ' -f1)
   
-  if [ -f "$state_file" ]; then
+  if [[ -f "$state_file" && "$mode" != "--initial" ]]; then
     read -r last_head last_state_hash < "$state_file"
   fi
 
   local did_something=false
 
-  # 1. New commit detection
-  if [[ "$current_head" != "$last_head" ]]; then
-    echo -e "\n\033[1;34m=== Commit: $(git log -1 --format='%h %s' 2>/dev/null) ===\033[0m"
+  # 1. Commit detection (or initial show)
+  if [[ "$current_head" != "$last_head" || "$mode" == "--initial" ]]; then
+    echo -e "\n\033[1;34m=== Current Commit: $(git log -1 --format='%h %s' 2>/dev/null) ===\033[0m"
     git_run show --summary --stat -p
     did_something=true
   fi
 
-  # 2. Working directory detection
-  if [[ "$current_state_hash" != "$last_state_hash" ]]; then
+  # 2. Working directory detection (or initial show)
+  if [[ "$current_state_hash" != "$last_state_hash" || "$mode" == "--initial" ]]; then
     local status=$(git status --porcelain)
     if [[ -n "$status" ]]; then
       echo -e "\n\033[1;32m=== Changes ===\033[0m"
@@ -95,19 +96,13 @@ update() {
 
 # Internal flag for watchexec to call back into the script
 if [[ "$1" == "--step" ]]; then
-  update
+  update "--step"
   exit 0
 fi
 
 # Main execution loop
-# Ensure state file is initialized so we don't dump the whole history on start
-# unless the user wants to see current changes.
-git_dir=$(git rev-parse --git-dir 2>/dev/null)
-state_file="$git_dir/watch-state"
-if [ ! -f "$state_file" ]; then
-    # On first run, we'll show current status if it's dirty
-    update
-fi
+# Always show the current state on launch
+update "--initial"
 
 if command -v watchexec >/dev/null 2>&1; then
   echo -e "\033[0;32mWatching with watchexec...\033[0m"
@@ -119,7 +114,7 @@ if command -v watchexec >/dev/null 2>&1; then
 else
   echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
   while true; do
-    update
+    update "--step"
     sleep 2
   done
 fi

--- a/git-watch
+++ b/git-watch
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+#
+# git-watch: A streaming perspective of git changes and commits.
+#
+# Monitors the current repository for:
+# - New commits (displays 'git show')
+# - Working directory & index changes (displays 'git diff HEAD' and untracked files)
+#
+# Prefers 'watchexec' for responsiveness but falls back to a loop.
+#
+
+# Check if we're in a git repo
+[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || {
+  echo "Error: Not a git repository." >&2
+  exit 1
+}
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+  echo "git-watch: A streaming perspective of git changes and commits."
+  echo
+  echo "Usage: git-watch"
+  echo
+  echo "Features:"
+  echo "  - Shows 'git show' on new commits"
+  echo "  - Shows 'git diff HEAD' on working tree/index changes"
+  echo "  - Shows content of new untracked files"
+  echo "  - Uses 'watchexec' if available for high-speed responsiveness"
+  echo "  - Uses your fancy pager (delta/diff-so-fancy) without blocking"
+  exit 0
+fi
+
+# Pager detection (compatible with delta, diff-so-fancy, etc.)
+pager_cmd=$(command -v delta || command -v diff-so-fancy)
+pipe_to_pager=${pager_cmd:+" | $pager_cmd"}
+
+git_run() {
+  # Use --no-pager to avoid interactive sessions
+  # Use --color=always to preserve color through the pipe
+  eval "git --no-pager \"\$@\" --color=always $pipe_to_pager"
+}
+
+# Cross-platform hashing for change detection
+hash_cmd=$(command -v shasum || command -v sha1sum || echo "cksum")
+
+update() {
+  local git_dir state_file
+  git_dir=$(git rev-parse --git-dir 2>/dev/null)
+  [ -n "$git_dir" ] || return
+  state_file="$git_dir/watch-state"
+
+  local current_head last_head current_state_hash last_state_hash
+  current_head=$(git rev-parse HEAD 2>/dev/null)
+  
+  # Capture staged, unstaged, and the presence of untracked files
+  current_state_hash=$( (git status --porcelain; git diff HEAD) | $hash_cmd | cut -d' ' -f1)
+  
+  if [ -f "$state_file" ]; then
+    read -r last_head last_state_hash < "$state_file"
+  fi
+
+  # 1. New commit detection
+  if [[ "$current_head" != "$last_head" ]]; then
+    echo -e "\n\033[1;34m=== Commit: $(git log -1 --format='%h %s' 2>/dev/null) ===\033[0m"
+    git_run show --summary --stat -p
+    # Update state immediately to avoid showing diff that is now committed
+    echo "$current_head $current_state_hash" > "$state_file"
+    return
+  fi
+
+  # 2. Working directory detection
+  if [[ "$current_state_hash" != "$last_state_hash" ]]; then
+    local status=$(git status --porcelain)
+    if [[ -n "$status" ]]; then
+      echo -e "\n\033[1;32m=== Changes ===\033[0m"
+      
+      # Show diff of tracked changes (staged and unstaged)
+      git_run diff HEAD
+      
+      # Show untracked files content
+      git ls-files --others --exclude-standard | while read -r f; do
+        if [[ -f "$f" ]]; then
+          echo -e "\033[1;33m[Untracked: $f]\033[0m"
+          git_run diff --no-index /dev/null "$f"
+        fi
+      done
+    fi
+    echo "$current_head $current_state_hash" > "$state_file"
+  fi
+}
+
+# Internal flag for watchexec to call back into the script
+if [[ "$1" == "--step" ]]; then
+  update
+  exit 0
+fi
+
+# Main execution loop
+# Ensure state file is initialized so we don't dump the whole history on start
+# unless the user wants to see current changes.
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+state_file="$git_dir/watch-state"
+if [ ! -f "$state_file" ]; then
+    # On first run, we'll show current status if it's dirty
+    update
+fi
+
+if command -v watchexec >/dev/null 2>&1; then
+  echo -e "\033[0;32mWatching with watchexec...\033[0m"
+  # -i .git: ignore most git internal changes
+  # -w .: watch working directory
+  # -w .git/HEAD: watch for commits
+  # --clear: optional? User said "streaming perspective", so probably NO clear.
+  watchexec -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step
+else
+  echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
+  while true; do
+    update
+    sleep 2
+  done
+fi

--- a/git-watch
+++ b/git-watch
@@ -59,13 +59,13 @@ update() {
     read -r last_head last_state_hash < "$state_file"
   fi
 
+  local did_something=false
+
   # 1. New commit detection
   if [[ "$current_head" != "$last_head" ]]; then
     echo -e "\n\033[1;34m=== Commit: $(git log -1 --format='%h %s' 2>/dev/null) ===\033[0m"
     git_run show --summary --stat -p
-    # Update state immediately to avoid showing diff that is now committed
-    echo "$current_head $current_state_hash" > "$state_file"
-    return
+    did_something=true
   fi
 
   # 2. Working directory detection
@@ -84,7 +84,11 @@ update() {
           git_run diff --no-index /dev/null "$f"
         fi
       done
+      did_something=true
     fi
+  fi
+
+  if [[ "$did_something" == "true" ]]; then
     echo "$current_head $current_state_hash" > "$state_file"
   fi
 }
@@ -110,8 +114,8 @@ if command -v watchexec >/dev/null 2>&1; then
   # -i .git: ignore most git internal changes
   # -w .: watch working directory
   # -w .git/HEAD: watch for commits
-  # --clear: optional? User said "streaming perspective", so probably NO clear.
-  watchexec -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step
+  # --quiet: suppress watchexec status messages
+  watchexec --quiet -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step
 else
   echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
   while true; do

--- a/git-watch
+++ b/git-watch
@@ -7,7 +7,7 @@
 # - New commits (displays 'git show')
 # - Working directory & index changes (displays 'git diff HEAD' and untracked files)
 #
-# Prefers 'watchexec' for responsiveness but falls back to a loop.
+# Requires 'watchexec' for responsiveness.
 #
 
 # Check if we're in a git repo
@@ -15,6 +15,12 @@
   echo "Error: Not a git repository." >&2
   exit 1
 }
+
+# Check for dependencies
+if ! command -v watchexec >/dev/null 2>&1; then
+  echo "Error: 'watchexec' is required for git-watch. Please install it (e.g., 'brew install watchexec')." >&2
+  exit 1
+fi
 
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
   echo "git-watch: A streaming perspective of git changes and commits."
@@ -27,8 +33,7 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
   echo "Features:"
   echo "  - Shows 'git show' on new commits"
   echo "  - Shows 'git diff HEAD' on working tree/index changes"
-  echo "  - Shows content of new untracked files"
-  echo "  - Uses 'watchexec' if available for high-speed responsiveness"
+  echo "  - Uses 'watchexec' for high-speed responsiveness"
   echo "  - Uses your fancy pager (delta/diff-so-fancy) without blocking"
   exit 0
 fi
@@ -132,21 +137,8 @@ if [ "$DEBUG_MODE" = true ]; then
   pass_debug="--debug"
 fi
 
-if command -v watchexec >/dev/null 2>&1; then
-  echo -e "\033[0;32mWatching with watchexec...\033[0m"
-  # --postpone: don't run immediately on start (we already did update --initial)
-  # --quiet: suppress watchexec status messages
-  watchexec --quiet --postpone -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step $pass_debug
-else
-  echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
-  while true; do
-    update "--step"
-    sleep 2
-  done
-fi
-  echo -e "\033[0;33mWatching with fallback loop (watchexec not found)...\033[0m"
-  while true; do
-    update "--step"
-    sleep 2
-  done
-fi
+echo -e "\033[0;32mWatching with watchexec...\033[0m"
+# --postpone: don't run immediately on start (we already did update --initial)
+# --quiet: suppress watchexec status messages
+# exec is used so that Ctrl-C goes directly to watchexec and terminates the session
+exec watchexec --quiet --postpone -i .git -w . -w "$(git rev-parse --git-dir)/HEAD" -- "$0" --step $pass_debug

--- a/man/man1/git-recent.1
+++ b/man/man1/git-recent.1
@@ -17,7 +17,7 @@ Display a help message.
 .SH KEYBINDINGS
 .TP
 .B Enter
-Checkout the selected branch. If the branch is already open in a separate git worktree, the script will provide instructions to jump there. (See README for automatic switching via a shell wrapper).
+Checkout the selected branch. If the branch is already open in a separate git worktree, the script will output the path to jump there. (See README for automatic switching via a small shell wrapper).
 .TP
 .B Up/Down arrow keys
 Navigate the branch list.

--- a/man/man1/git-recent.1
+++ b/man/man1/git-recent.1
@@ -17,7 +17,7 @@ Display a help message.
 .SH KEYBINDINGS
 .TP
 .B Enter
-Checkout the selected branch.
+Checkout the selected branch. If the branch is already open in a separate git worktree, the script will provide instructions to jump there. (See README for automatic switching via a shell wrapper).
 .TP
 .B Up/Down arrow keys
 Navigate the branch list.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "List recent git branches, select one for checkout. See branch commits and diffs, all formatted so fancy",
   "bin": {
     "git-recent": "git-recent",
-    "git-recent-og": "git-recent-og"
+    "git-recent-og": "git-recent-og",
+    "git-watch": "git-watch"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.md
+++ b/readme.md
@@ -61,18 +61,6 @@ function recent
 end
 ```
 
-# `git watch`
-
-`git watch` provides a streaming perspective of changes and commits in your current branch. This is particularly useful for monitoring an automated coding agent or your own background work.
-
-    git watch
-
-- Displays `git show` when a new commit is made.
-- Displays `git diff` when tracked files are modified.
-- Displays full content of new untracked files.
-- Uses your configured pager (e.g. `delta` or `diff-so-fancy`) for formatting without blocking.
-- Uses `watchexec` for high responsiveness if available, or falls back to polling.
-
 --------------------------------
 
 # `git recent-og`

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,28 @@ Type or use arrow keys to navigate your list of branches.
 
 Hit `ctrl-o` to see the branch diff.
 
+#### Worktree Support
+
+If a branch is already open in a separate git worktree, `git recent` will detect it and provide instructions to `cd` there. To enable **automatic** directory switching, add this wrapper function to your `.bashrc` or `.zshrc`:
+
+```bash
+# Optional wrapper to enable automatic worktree jumping
+git-recent() {
+  local output
+  # Set the flag to let the script know we can handle the CD
+  output=$(GIT_RECENT_AUTO_CD=1 command git-recent "$@")
+  
+  if echo "$output" | grep -q "^__CD__:"; then
+    local target=$(echo "$output" | grep "^__CD__:" | cut -d: -f2-)
+    cd "$target"
+    # Print the output but hide the control line
+    echo "$output" | grep -v "^__CD__:"
+  else
+    echo "$output"
+  fi
+}
+```
+
 --------------------------------
 
 # `git recent-og`

--- a/readme.md
+++ b/readme.md
@@ -39,24 +39,26 @@ Hit `ctrl-o` to see the branch diff.
 
 #### Worktree Support
 
-If a branch is already open in a separate git worktree, `git recent` will detect it and provide instructions to `cd` there. To enable **automatic** directory switching, add this wrapper function to your `.bashrc` or `.zshrc`:
+If a branch is already open in a separate git worktree, `git recent` will detect it and provide instructions to `cd` there. To enable **automatic** directory switching, add one of these wrapper functions to your shell config:
 
+##### Bash / Zsh (in `.bashrc` or `.zshrc`)
 ```bash
-# Optional wrapper to enable automatic worktree jumping
-git-recent() {
-  local output
-  # Set the flag to let the script know we can handle the CD
-  output=$(GIT_RECENT_AUTO_CD=1 command git-recent "$@")
-  
-  if echo "$output" | grep -q "^__CD__:"; then
-    local target=$(echo "$output" | grep "^__CD__:" | cut -d: -f2-)
-    cd "$target"
-    # Print the output but hide the control line
-    echo "$output" | grep -v "^__CD__:"
-  else
-    echo "$output"
-  fi
+recent() {
+  local o=$(command git-recent "$@")
+  [ -d "$o" ] && cd "$o" || [ -n "$o" ] && echo "$o"
 }
+```
+
+##### Fish (in `~/.config/fish/config.fish`)
+```fish
+function recent
+  set -l o (command git-recent $argv)
+  if test -d "$o"
+    cd $o
+  else if test -n "$o"
+    echo $o
+  end
+end
 ```
 
 --------------------------------

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,18 @@ function recent
 end
 ```
 
+# `git watch`
+
+`git watch` provides a streaming perspective of changes and commits in your current branch. This is particularly useful for monitoring an automated coding agent or your own background work.
+
+    git watch
+
+- Displays `git show` when a new commit is made.
+- Displays `git diff` when tracked files are modified.
+- Displays full content of new untracked files.
+- Uses your configured pager (e.g. `delta` or `diff-so-fancy`) for formatting without blocking.
+- Uses `watchexec` for high responsiveness if available, or falls back to polling.
+
 --------------------------------
 
 # `git recent-og`


### PR DESCRIPTION
requires using a 'recent' bash function cuz this utility can't 'cd' for you. 

but its nice.

---

also in this PR a git-watch command (requires watchexec) that i like for when my agent is busy and i just want to watch its edits.   it's not amazing UX but... its something.