### PR TITLE
Add Ctrl-G shortcut to open Gerrit CLs in browser

### DIFF
--- a/git-recent
+++ b/git-recent
@@ -21,6 +21,8 @@ if [[ "$1" == "--help" ]]; then
   echo "Keybindings:"
   echo "  Enter:      Checkout the selected branch (or jump to its worktree if open elsewhere)"
   echo "  Ctrl-O:     Show the diff of the selected branch against the main/master branch"
+  echo "  Ctrl-Y:     Copy branch name to clipboard"
+  echo "  Ctrl-G:     Open Gerrit CL in browser (when using --cl)"
   echo "  Ctrl-C:     Exit"
   exit 0
 fi
@@ -53,6 +55,14 @@ elif command -v xclip >/dev/null; then
   copy_cmd="printf '%s' {} | xclip -selection clipboard"
 elif command -v xsel >/dev/null; then
   copy_cmd="printf '%s' {} | xsel --clipboard"
+fi
+
+# Open URL in browser, variants for mac/linux
+open_cmd="echo 'Could not open URL.'"
+if [[ "$OSTYPE" == "darwin"* ]] || command -v open >/dev/null 2>&1; then
+  open_cmd="open"
+elif command -v xdg-open >/dev/null 2>&1; then
+  open_cmd="xdg-open"
 fi
 
 _get_worktree_for_branch() {
@@ -116,16 +126,29 @@ _browse_branches() {
         # TODO: use `git config branch.$(git rev-parse --abbrev-ref HEAD).gerritissue` and gerritserver to avoid using `git cl status`
         printf "$YELLOW%s$DIM%s \033]8;;%s\a%s\033]8;;\a$NC\n" "$branch_name" "$wt_symbol" "https://$review_url" "$review_url"
       done \
-    | fzf  \
-        $filterarg --ansi -- --layout=reverse --multi --height=90% --min-height=20  \
-        --border-label-pos=2 --border-label '🌲 Branches' --border \
-        --no-hscroll --no-multi \
-        --preview-window='right,70%,border-left,border-rounded' --preview="$uniqcommits_cmd" --preview-label="Commits unique to branch" \
-        --header $'ENTER (checkout)\nCTRL-O (show branch diff)\nCTRL-Y (copy name to clipboard)' \
-        --bind 'preview-scroll-up:preview-up+preview-up+preview-up' \
-        --bind 'preview-scroll-down:preview-down+preview-down+preview-down' \
-        --bind "ctrl-y:execute-silent($copy_cmd)" \
-        --bind "ctrl-o:preview:$diffbranch_cmd"
+    | {
+        fzf_header=$'ENTER (checkout)\nCTRL-O (show branch diff)\nCTRL-Y (copy name to clipboard)'
+        fzf_binds=(
+          --bind 'preview-scroll-up:preview-up+preview-up+preview-up'
+          --bind 'preview-scroll-down:preview-down+preview-down+preview-down'
+          --bind "ctrl-y:execute-silent($copy_cmd)"
+          --bind "ctrl-o:preview:$diffbranch_cmd"
+        )
+
+        if [ "$show_cl" = true ]; then
+          fzf_header+=$'\nCTRL-G (open CL in browser)'
+          # Extract the last column (the URL). Proceed if it looks like a URL.
+          fzf_binds+=( --bind "ctrl-g:execute-silent(url=\$(echo {} | awk '{print \$NF}'); [[ \$url == *.*/* ]] && $open_cmd \"https://\$url\")" )
+        fi
+
+        fzf  \
+          $filterarg --ansi -- --layout=reverse --multi --height=90% --min-height=20  \
+          --border-label-pos=2 --border-label '🌲 Branches' --border \
+          --no-hscroll --no-multi \
+          --preview-window='right,70%,border-left,border-rounded' --preview="$uniqcommits_cmd" --preview-label="Commits unique to branch" \
+          --header "$fzf_header" \
+          "${fzf_binds[@]}"
+      }
 }
 output="$(_browse_branches)"
 line_count=$(printf "%s" "$output" | wc -l)


### PR DESCRIPTION
- Implement OS-aware open command for macOS and Linux.
- Dynamically extend fzf header and bindings when --cl flag is active.
- Add Ctrl-G binding to extract and open the CL URL from the selected line.
- Update help documentation with Ctrl-Y and Ctrl-G shortcuts.